### PR TITLE
Add Supabase keep-alive (stop free-tier auto-pause)

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,0 +1,85 @@
+name: Supabase Keep-Alive
+
+# Why this exists:
+# Supabase free-tier projects auto-PAUSE after ~7 days with no incoming API
+# traffic, and are permanently DELETED after ~90 days paused. This workflow
+# sends a tiny daily request to the project's REST + Auth endpoints, which
+# counts as activity and resets the inactivity timer. Costs nothing on a
+# public repo. (Internal DB cron does NOT count — the pause is based on
+# external API ingress, so the ping must come from outside.)
+
+on:
+  schedule:
+    # Daily at 07:23 UTC (off the hour, as GitHub recommends, to avoid
+    # congestion-related skips). Daily gives ~7x safety margin vs the pause window.
+    - cron: '23 7 * * *'
+  workflow_dispatch: {}   # lets you run it manually from the Actions tab anytime
+
+# Avoid stacking runs if one is slow/delayed.
+concurrency:
+  group: supabase-keepalive
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    name: Ping Supabase
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hit REST + Auth endpoints
+        env:
+          # Public anon key — identical to the one shipped in the deployed
+          # frontend bundle, so there is no secret to protect here. RLS still
+          # blocks all data; this only registers "the project is in use".
+          SUPABASE_URL: https://yvuenajqwmbfyecfoalc.supabase.co
+          SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inl2dWVuYWpxd21iZnllY2ZvYWxjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODAwMzA5MDUsImV4cCI6MjA5NTYwNjkwNX0.dFxWsFPfNyNiW0OmkW-mh7eNPQ3WAZ5i_TpFnSNvWvE
+        run: |
+          set -euo pipefail
+          echo "Pinging REST (PostgREST)..."
+          rest=$(curl -fsS -o /dev/null -w '%{http_code}' \
+            "$SUPABASE_URL/rest/v1/game_states?select=user_id&limit=1" \
+            -H "apikey: $SUPABASE_ANON_KEY" \
+            -H "Authorization: Bearer $SUPABASE_ANON_KEY")
+          echo "  REST -> HTTP $rest"
+
+          echo "Pinging Auth (GoTrue)..."
+          auth=$(curl -fsS -o /dev/null -w '%{http_code}' \
+            "$SUPABASE_URL/auth/v1/settings" \
+            -H "apikey: $SUPABASE_ANON_KEY")
+          echo "  Auth -> HTTP $auth"
+
+          if [ "$rest" = "200" ] && [ "$auth" = "200" ]; then
+            echo "Keep-alive OK — project is awake."
+          else
+            echo "::error::Unexpected status (REST=$rest, Auth=$auth). The project may be paused/deleted."
+            exit 1
+          fi
+
+  prevent-self-disable:
+    name: Prevent workflow auto-disable
+    needs: ping
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # only used for the rare heartbeat commit below
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Heartbeat commit only if repo idle 45+ days
+        run: |
+          set -euo pipefail
+          last=$(git log -1 --format=%ct)
+          now=$(date +%s)
+          age_days=$(( (now - last) / 86400 ))
+          echo "Most recent commit: ${age_days} day(s) ago."
+          if [ "$age_days" -ge 45 ]; then
+            echo "Repo idle 45+ days — committing a heartbeat so GitHub won't disable this cron."
+            git config user.name  "keepalive-bot"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            mkdir -p .github
+            date -u +"%Y-%m-%dT%H:%M:%SZ" > .github/.keepalive
+            git add .github/.keepalive
+            git commit -m "chore: keepalive heartbeat [skip ci]"
+            git push
+          else
+            echo "Repo recently active — no heartbeat needed."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ Thumbs.db
 supabase/.branches/
 supabase/.temp/
 supabase/logs/
+
+# Supabase backups (sensitive PII - never commit, esp. on a public repo)
+*.backup.gz
+*.storage.zip
+db_cluster-*

--- a/supabase/config.local.toml
+++ b/supabase/config.local.toml
@@ -1,7 +1,7 @@
 # Supabase Local Environment Configuration
 # This configuration is used for local development
 
-project_id = "lxjetnrmjyazegwnymkk"
+project_id = "yvuenajqwmbfyecfoalc"
 api_port = 54321
 db_port = 54322
 studio_port = 54323

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,1 @@
-project_id = "lxjetnrmjyazegwnymkk"
+project_id = "yvuenajqwmbfyecfoalc"


### PR DESCRIPTION
## Why
The production Supabase project auto-paused after >90 days idle and became non-restorable, taking the prod app down. It's been rebuilt under a new ref. This prevents a repeat — for free.

## What this adds
- **`.github/workflows/supabase-keepalive.yml`** — a daily cron (`07:23 UTC`) that pings the Supabase REST + Auth endpoints. Incoming API traffic is what resets Supabase's inactivity timer, so this keeps the free-tier project awake. Also runnable on demand via **workflow_dispatch**.
- **Self-disable guard** — GitHub disables scheduled workflows after 60 days of zero repo commits. A second job commits a tiny `.github/.keepalive` heartbeat *only* if the repo has been idle 45+ days, so the cron never silently dies.
- **`supabase/config*.toml`** repointed to the rebuilt project.
- **`.gitignore`** now excludes DB backup artifacts (`*.backup.gz`, `*.storage.zip`, `db_cluster-*`) so the sensitive cluster dump can never be committed to this public repo.

## Notes
- The anon key embedded in the workflow is the same **public** key shipped in the frontend bundle — RLS still blocks all data; the ping only registers activity. No secret needed.
- Costs nothing (scheduled Actions are free/unlimited on public repos).
- Once merged to `master`, the schedule activates automatically. You can also trigger it immediately from the Actions tab to confirm it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)